### PR TITLE
Update to use new app name and host

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+* Uses new application name & URL (nokotime.com)
+
 # 1.2.0
 
 * Added methods for project group resources

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/freckles.svg)](https://badge.fury.io/rb/freckles) [![Build Status](https://api.travis-ci.org/timcraft/freckles.svg?branch=master)](https://travis-ci.org/timcraft/freckles)
 
 
-Ruby client for [Version 2 of the Freckle API](https://developer.letsfreckle.com/v2/).
+Ruby client for [Version 2 of the Freckle/Noko API](https://developer.nokotime.com/v2/).
 
 
 ## Install

--- a/freckles.gemspec
+++ b/freckles.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name = 'freckles'
-  s.version = '1.2.0'
+  s.version = '1.3.0'
   s.license = 'MIT'
   s.platform = Gem::Platform::RUBY
   s.authors = ['Tim Craft']
   s.email = ['mail@timcraft.com']
   s.homepage = 'https://github.com/timcraft/freckles'
-  s.description = 'Ruby client for Version 2 of the Freckle API'
-  s.summary = 'Ruby client for Version 2 of the Freckle API'
+  s.description = 'Ruby client for Version 2 of the Freckle/Noko API'
+  s.summary = 'Ruby client for Version 2 of the Freckle/Noko API'
   s.files = Dir.glob('{lib,test}/**/*') + %w(LICENSE.txt README.md freckles.gemspec)
   s.required_ruby_version = '>= 1.9.3'
   s.add_development_dependency('rake', '~> 12')

--- a/lib/freckle/client.rb
+++ b/lib/freckle/client.rb
@@ -17,7 +17,7 @@ module Freckle
 
       @user_agent = options.fetch(:user_agent) { "freckles/#{VERSION} ruby/#{RUBY_VERSION}" }
 
-      @host = 'api.letsfreckle.com'
+      @host = 'api.nokotime.com'
 
       @http = Net::HTTP.new(@host, Net::HTTP.https_default_port)
 

--- a/test/freckle/client/options_test.rb
+++ b/test/freckle/client/options_test.rb
@@ -2,7 +2,7 @@ require_relative '../client_test'
 
 class FreckleClientOptionsTest < FreckleClientTest
   def user_agent
-    'account.letsfreckle.com'
+    'account.nokotime.com'
   end
 
   def access_token

--- a/test/freckle/client/response_test.rb
+++ b/test/freckle/client/response_test.rb
@@ -6,7 +6,7 @@ class FreckleClientResponseTest < FreckleClientTest
   end
 
   def test_rel_next_link
-    link = '<https://api.letsfreckle.com/v2/entries?page=3>; rel="next"'
+    link = '<https://api.nokotime.com/v2/entries?page=3>; rel="next"'
 
     expect_request(:get, "#{base_url}/entries").to_return(response('Link' => link))
 
@@ -14,7 +14,7 @@ class FreckleClientResponseTest < FreckleClientTest
   end
 
   def test_rel_prev_link
-    link = '<https://api.letsfreckle.com/v2/entries?page=2>; rel="prev"'
+    link = '<https://api.nokotime.com/v2/entries?page=2>; rel="prev"'
 
     expect_request(:get, "#{base_url}/entries").to_return(response('Link' => link))
 
@@ -22,7 +22,7 @@ class FreckleClientResponseTest < FreckleClientTest
   end
 
   def test_rel_last_link
-    link = '<https://api.letsfreckle.com/v2/entries?page=50>; rel="last"'
+    link = '<https://api.nokotime.com/v2/entries?page=50>; rel="last"'
 
     expect_request(:get, "#{base_url}/entries").to_return(response('Link' => link))
 
@@ -30,7 +30,7 @@ class FreckleClientResponseTest < FreckleClientTest
   end
 
   def test_rel_first_link
-    link = '<https://api.letsfreckle.com/v2/entries?page=1>; rel="first"'
+    link = '<https://api.nokotime.com/v2/entries?page=1>; rel="first"'
 
     expect_request(:get, "#{base_url}/entries").to_return(response('Link' => link))
 

--- a/test/freckle/client_test.rb
+++ b/test/freckle/client_test.rb
@@ -16,7 +16,7 @@ class FreckleClientTest < Minitest::Test
   end
 
   def base_url
-    'https://api.letsfreckle.com/v2'
+    'https://api.nokotime.com/v2'
   end
 
   def auth_header


### PR DESCRIPTION
**IMPORTANT: DO NOT MERGE BEFORE MARCH 25, 2019**

This updates the freckles Freckle/Noko API client to use the new URL for Freckle's/Noko's API V2 (api.nokotime.com). This new hostname will become active on or before March 25, 2019.

This PR also updates the gem version to 1.3.0.